### PR TITLE
Allows models to not have updated_at field.

### DIFF
--- a/src/ReplaceableModel.php
+++ b/src/ReplaceableModel.php
@@ -63,7 +63,7 @@ trait ReplaceableModel
                 if(empty($set[static::CREATED_AT])) {
                     $set[static::CREATED_AT] = Carbon::now();
                 }
-                if(empty($set[static::UPDATED_AT])) {
+                if(! is_null($model::UPDATED_AT) && empty($set[static::UPDATED_AT])) {
                     $set[static::UPDATED_AT] = Carbon::now();
                 }
                 $attributes[$key] = $set;


### PR DESCRIPTION
Checks that the UPDATED_AT constant on the model isn't null, which allows for models to not have the "updated at" timestamp.