### PR TITLE
Add support for Laravel 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "illuminate/support": "~5.1",
+        "illuminate/support": "~5.1 || ^6.0",
         "php" : "~5.5|~7.0"
     },
     "require-dev": {


### PR DESCRIPTION
Updates the version constraint on `illuminate/support` to work with Laravel 6.x